### PR TITLE
DFL_4.4.1 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG
 
+## [v4.4.1] - 2025-07-26
+
+### Added
+- Cooldown period for FPS cap increase logic
+    - Previously, when GPU usage stayed below the lower threshold for 3 continuous seconds (default `delaybeforeincrease`), the app began increasing the FPS cap once per second, leading to noticeable 1-second microstutters until GPU usage stabilized.
+    - Now, after each FPS cap increase, the app enters a cooldown period (equal to `delaybeforeincrease`) before attempting another increase, only if the low GPU usage condition still holds.
+    - Effect: This change spaces out FPS cap increases, making transitions from high-demand to low-demand scenes relatively smoother.
+        - Example: If 3 FPS cap increases are needed:
+            - Before: 3 microstutters over 3 seconds -> very jarring
+            - Now: 3 microstutters over 9 seconds -> less intrusive
+
+### Changed
+- Interal: Autopilot’s monitoring loop is now decoupled from the GUI update loop.
+- Increased internal wait times at various stages to reduce unnecessary polling and reduce CPU overhead.
+
+### Fixed
+- Reduced CPU usage when idle and minimized to tray
+    - The app previously consumed more CPU when idle due to continuous GUI updates.
+    - GUI updates are now paused when minimized, resulting in significantly lower CPU usage while the app is idle in the background.
+
 ## [v4.4.0] - 2025-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Dynamic FPS Limiter v4.4
 
-A lightweight companion app for RTSS that uses it's profile modification API to dynamically adjusts framerate limits based on real-time GPU and CPU usage. It's especially useful for reducing input latency when using frame generation tools like Lossless Scaling.
+A lightweight companion app for RTSS that uses it's profile modification API to dynamically adjust framerate limits based on real-time GPU and CPU usage. 
+- Instead of relying on a fixed FPS cap below average framerates for smooth gameplay, it intelligently raises the cap when performance headroom is available, allowing consistently smooth frametimes, with the caveat of a momentary stutter during FPS limit transition.
+- Especially useful for reducing input latency when using frame generation tools like Lossless Scaling, by ensuring there's always enough GPU headroom.
+- When paired with adaptive frame generation in Lossless Scaling, it enables a constant high refresh rate experience with lower power draw and reduced GPU temperatures, without noticeable visual compromises or input lag.
 
 <p align="center">
   <img src="docs/Images/v4.1.0_2025-05-31-09-50-18.gif" width="45%" />
@@ -20,6 +23,12 @@ If you'd like to inspect or customize the source code, follow the instructions i
 4. **Recommended**: Add `DynamicFPSLimiter.exe`as an exclusion in RTSS to reduce the app's CPU performance overhead. 
     - This can be done by holding the **Shift** key and clicking **Add** in RTSS, while the app is running.
     - **Note**: While not strictly necessary, this step is strongly recommended if you have disabled 'passive waiting' for the Global profile in RTSS
+
+Watch the demo here! (Based on v4.2.0)
+
+<a href="https://www.youtube.com/watch?v=6r3l5ebymew" target="_blank" rel="noopener noreferrer">
+  <img src="https://img.youtube.com/vi/6r3l5ebymew/hqdefault.jpg" width="45%" alt="Watch the demo here! (Based on v4.2.0)">
+</a>
 
 > [!NOTE]
 > - This app requires Rivatuner Statistics Server (RTSS) running in the background to function. Ensure RTSS is installed before running the app!

--- a/src/core/DFL_v4.py
+++ b/src/core/DFL_v4.py
@@ -1,5 +1,5 @@
 # DFL_v4.py
-# Dynamic FPS Limiter v4.4.0
+# Dynamic FPS Limiter v4.4.1
 
 import ctypes
 ctypes.windll.shcore.SetProcessDpiAwareness(2)
@@ -569,7 +569,7 @@ with dpg.window(label=app_title, tag="Primary Window"):
         dpg.add_image(icon_texture, tag="icon", width=20, height=20)
         dpg.add_text(app_title, tag="app_title")
         #dpg.bind_item_font("app_title", bold_font)
-        dpg.add_text("v4.4.0")
+        dpg.add_text("v4.4.1")
         dpg.add_spacer(width=310)
 
         dpg.add_image_button(texture_tag=minimize_texture, tag="minimize", callback=tray.minimize_to_tray, width=20, height=20)

--- a/src/core/DFL_v4.py
+++ b/src/core/DFL_v4.py
@@ -417,7 +417,7 @@ def gui_update_loop():
 
         # Wait until tray is not active
         while tray.is_tray_active and gui_running:
-            time.sleep(0.5)  # Sleep until tray is not active
+            time.sleep(1)  # Sleep until tray is not active
 
         if not running:
             try:

--- a/src/core/DFL_v4.py
+++ b/src/core/DFL_v4.py
@@ -413,7 +413,11 @@ gui_running = True
 def gui_update_loop():
     global gui_running, running
 
-    while gui_running:  # Changed from True to gui_running
+    while gui_running:
+
+        # Wait until tray is not active
+        while tray.is_tray_active and gui_running:
+            time.sleep(0.5)  # Sleep until tray is not active
 
         if not running:
             try:

--- a/src/metadata/version.txt
+++ b/src/metadata/version.txt
@@ -2,8 +2,8 @@
 
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(4, 4, 0, 0),
-    prodvers=(4, 4, 0, 0),
+    filevers=(4, 4, 1, 0),
+    prodvers=(4, 4, 1, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x4,
@@ -19,11 +19,11 @@ VSVersionInfo(
           [
             StringStruct('CompanyName', 'SameSalamander5710'),
             StringStruct('FileDescription', 'DynamicFPSLimiter'),
-            StringStruct('FileVersion', '4.4.0'),
+            StringStruct('FileVersion', '4.4.1'),
             StringStruct('InternalName', 'DynamicFPSLimiter'),
             StringStruct('OriginalFilename', 'DynamicFPSLimiter.exe'),
             StringStruct('ProductName', 'DynamicFPSLimiter'),
-            StringStruct('ProductVersion', '4.4.0')
+            StringStruct('ProductVersion', '4.4.1')
           ]
         )
       ]


### PR DESCRIPTION
DFL_4.4.1 update

## [v4.4.1] - 2025-07-26

### Added
- Cooldown period for FPS cap increase logic
    - Previously, when GPU usage stayed below the lower threshold for 3 continuous seconds (default `delaybeforeincrease`), the app began increasing the FPS cap once per second, leading to noticeable 1-second microstutters until GPU usage stabilized.
    - Now, after each FPS cap increase, the app enters a cooldown period (equal to `delaybeforeincrease`) before attempting another increase, only if the low GPU usage condition still holds.
    - Effect: This change spaces out FPS cap increases, making transitions from high-demand to low-demand scenes relatively smoother.
        - Example: If 3 FPS cap increases are needed:
            - Before: 3 microstutters over 3 seconds -> very jarring
            - Now: 3 microstutters over 9 seconds -> less intrusive

### Changed
- Interal: Autopilot’s monitoring loop is now decoupled from the GUI update loop.
- Increased internal wait times at various stages to reduce unnecessary polling and reduce CPU overhead.

### Fixed
- Reduced CPU usage when idle and minimized to tray
    - The app previously consumed more CPU when idle due to continuous GUI updates.
    - GUI updates are now paused when minimized, resulting in significantly lower CPU usage while the app is idle in the background.